### PR TITLE
Explicitly specify operation ids

### DIFF
--- a/src/TomKerkhove.Connectors.ApplicationInsights/Controllers/EventsController.cs
+++ b/src/TomKerkhove.Connectors.ApplicationInsights/Controllers/EventsController.cs
@@ -13,6 +13,7 @@ namespace TomKerkhove.Connectors.ApplicationInsights.Controllers
         /// <param name="eventMetadata">Metadata concerning the event to track</param>
         [HttpPost]
         [Route("events")]
+        [SwaggerOperation("events")]
         [SwaggerResponse(HttpStatusCode.NoContent, description: "Event was successfully written to Azure Application Insights")]
         [SwaggerResponse(HttpStatusCode.BadRequest, description: "Specified event metadata was invalid")]
         public IHttpActionResult Event([FromBody]Contracts.v1.EventMetadata eventMetadata)

--- a/src/TomKerkhove.Connectors.ApplicationInsights/Controllers/MetricsController.cs
+++ b/src/TomKerkhove.Connectors.ApplicationInsights/Controllers/MetricsController.cs
@@ -13,7 +13,8 @@ namespace TomKerkhove.Connectors.ApplicationInsights.Controllers
         /// </summary>
         /// <param name="metricMetadata">Metadata concerning the metric to track</param>
         [HttpPost]
-        [Route("metics")]
+        [Route("metrics")]
+        [SwaggerOperation("metrics")]
         [SwaggerResponse(HttpStatusCode.NoContent, description: "Metric was successfully written to Azure Application Insights")]
         [SwaggerResponse(HttpStatusCode.BadRequest, description: "Specified metric metadata was invalid")]
         public IHttpActionResult Metric([FromBody]Contracts.v1.BasicMetricMetadata metricMetadata)
@@ -38,7 +39,8 @@ namespace TomKerkhove.Connectors.ApplicationInsights.Controllers
         /// </summary>
         /// <param name="metricMetadata">Metadata concerning the metric to track</param>
         [HttpPost]
-        [Route("metics/sampling")]
+        [Route("metrics/sampling")]
+        [SwaggerOperation("metrics/sampling")]
         [SwaggerResponse(HttpStatusCode.NoContent, description: "Metric was successfully written to Azure Application Insights")]
         [SwaggerResponse(HttpStatusCode.BadRequest, description: "Specified metric metadata was invalid")]
         public IHttpActionResult Metric([FromBody]Contracts.v1.SampledMetricMetadata metricMetadata)

--- a/src/TomKerkhove.Connectors.ApplicationInsights/Controllers/TracesController.cs
+++ b/src/TomKerkhove.Connectors.ApplicationInsights/Controllers/TracesController.cs
@@ -16,7 +16,8 @@ namespace TomKerkhove.Connectors.ApplicationInsights.Controllers
         /// </summary>
         /// <param name="traceMetadata">Metadata concerning the trace to track</param>
         [HttpPost]
-        [Route("trace")]
+        [Route("traces")]
+        [SwaggerOperation("traces")]
         [SwaggerResponse(HttpStatusCode.NoContent, description: "Trace was successfully written to Azure Application Insights")]
         [SwaggerResponse(HttpStatusCode.BadRequest, description: "Specified trace metadata was invalid")]
         public IHttpActionResult Trace([FromBody]TraceMetadata traceMetadata)


### PR DESCRIPTION
Explicitly specify operation ids so that the Logic Apps editor includes all operations in the list